### PR TITLE
Adds a number of Python library equivalent functions to the Ruby interface

### DIFF
--- a/ext/tokenizers/src/encoding.rs
+++ b/ext/tokenizers/src/encoding.rs
@@ -57,4 +57,42 @@ impl RbEncoding {
             .map(|e| e.into())
             .collect()
     }
+
+    pub fn word_to_tokens(&self, word_index: u32, sequence_index: usize) -> Option<(usize, usize)> {
+      self.encoding
+          .word_to_tokens(word_index, sequence_index)
+    }
+
+    pub fn word_to_chars(&self, word_index: u32, sequence_index: usize) -> Option<(usize, usize)> {
+        self.encoding
+            .word_to_chars(word_index, sequence_index)
+    }
+
+    pub fn token_to_sequence(&self, token_index: usize) -> Option<usize> {
+        self.encoding
+            .token_to_sequence(token_index)
+    }
+
+    pub fn token_to_chars(&self, token_index: usize) -> Option<(usize, usize)> {
+        let (_, offsets) = self.encoding
+                               .token_to_chars(token_index)?;
+        Some(offsets)
+    }
+
+    pub fn token_to_word(&self, token_index: usize) -> Option<u32> {
+        let (_, word_idx) = self.encoding
+                                .token_to_word(token_index)?;
+        Some(word_idx)
+    }
+
+    pub fn char_to_token(&self, char_pos: usize, sequence_index: usize) -> Option<usize> {
+        self.encoding
+            .char_to_token(char_pos, sequence_index)
+    }
+
+    pub fn char_to_word(&self, char_pos: usize, sequence_index: usize) -> Option<u32> {
+        self.encoding
+            .char_to_word(char_pos, sequence_index)
+    }
+
 }

--- a/ext/tokenizers/src/lib.rs
+++ b/ext/tokenizers/src/lib.rs
@@ -38,11 +38,17 @@ fn init() -> RbResult<()> {
         "add_special_tokens",
         method!(RbTokenizer::add_special_tokens, 1),
     )?;
+    class.define_method(
+        "add_tokens",
+        method!(RbTokenizer::add_tokens, 1),
+    )?;
     class.define_method("_encode", method!(RbTokenizer::encode, 2))?;
     class.define_method("decode", method!(RbTokenizer::decode, 1))?;
     class.define_method("decoder=", method!(RbTokenizer::set_decoder, 1))?;
     class.define_method("pre_tokenizer=", method!(RbTokenizer::set_pre_tokenizer, 1))?;
     class.define_method("normalizer=", method!(RbTokenizer::set_normalizer, 1))?;
+    class.define_method("token_to_id", method!(RbTokenizer::token_to_id, 1))?;
+    class.define_method("id_to_token", method!(RbTokenizer::id_to_token, 1))?;
 
     let class = module.define_class("Encoding", Default::default())?;
     class.define_method("n_sequences", method!(RbEncoding::n_sequences, 0))?;
@@ -58,6 +64,13 @@ fn init() -> RbResult<()> {
     )?;
     class.define_method("attention_mask", method!(RbEncoding::attention_mask, 0))?;
     class.define_method("overflowing", method!(RbEncoding::overflowing, 0))?;
+    class.define_method("_word_to_tokens", method!(RbEncoding::word_to_tokens, 2))?;
+    class.define_method("_word_to_chars", method!(RbEncoding::word_to_chars, 2))?;
+    class.define_method("token_to_sequence", method!(RbEncoding::token_to_sequence, 1))?;
+    class.define_method("token_to_chars", method!(RbEncoding::token_to_chars, 1))?;
+    class.define_method("token_to_word", method!(RbEncoding::token_to_word, 1))?;
+    class.define_method("_char_to_token", method!(RbEncoding::char_to_token, 2))?;
+    class.define_method("_char_to_word", method!(RbEncoding::char_to_word, 2))?;
 
     let class = module.define_class("BPEDecoder", Default::default())?;
     class.define_singleton_method("new", function!(RbBPEDecoder::new, 0))?;

--- a/ext/tokenizers/src/tokenizer.rs
+++ b/ext/tokenizers/src/tokenizer.rs
@@ -32,7 +32,17 @@ impl RbTokenizer {
 
     pub fn add_special_tokens(&self, tokens: Vec<String>) {
         let tokens: Vec<AddedToken> = tokens.iter().map(|t| AddedToken::from(t, true)).collect();
-        self.tokenizer.borrow_mut().add_special_tokens(&tokens);
+        self.tokenizer
+            .borrow_mut()
+            .add_special_tokens(&tokens);
+        // TODO return self
+    }
+
+    pub fn add_tokens(&self, tokens: Vec<String>) {
+        let tokens: Vec<AddedToken> = tokens.iter().map(|t| AddedToken::from(t, true)).collect();
+        self.tokenizer
+            .borrow_mut()
+            .add_tokens(&tokens);
         // TODO return self
     }
 
@@ -67,5 +77,18 @@ impl RbTokenizer {
         self.tokenizer
             .borrow_mut()
             .with_normalizer(normalizer.normalizer);
+    }
+
+    pub fn token_to_id(&self, token: String) -> Option<u32> {
+        self.tokenizer
+            .borrow()
+            .token_to_id(&token)
+    }
+
+
+    pub fn id_to_token(&self, id: u32) -> Option<String> {
+        self.tokenizer
+            .borrow()
+            .id_to_token(id)
     }
 }

--- a/lib/tokenizers.rb
+++ b/lib/tokenizers.rb
@@ -7,6 +7,7 @@ end
 
 # modules
 require "tokenizers/char_bpe_tokenizer"
+require "tokenizers/encoding"
 require "tokenizers/from_pretrained"
 require "tokenizers/tokenizer"
 require "tokenizers/version"

--- a/lib/tokenizers/encoding.rb
+++ b/lib/tokenizers/encoding.rb
@@ -1,0 +1,19 @@
+module Tokenizers
+  class Encoding
+    def word_to_tokens(word_index, sequence_index = 0)
+      _word_to_tokens(word_index, sequence_index)
+    end
+
+    def word_to_chars(word_index, sequence_index = 0)
+      _word_to_chars(word_index, sequence_index)
+    end
+
+    def char_to_token(char_pos, sequence_index = 0)
+      _char_to_token(char_pos, sequence_index)
+    end
+
+    def char_to_word(char_pos, sequence_index = 0)
+      _char_to_word(word_index, sequence_index)
+    end
+  end
+end

--- a/test/tokenizers_test.rb
+++ b/test/tokenizers_test.rb
@@ -28,6 +28,13 @@ class TokenizersTest < Minitest::Test
     assert_equal expected_tokens, encoded.tokens
     assert_equal expected_word_ids, encoded.word_ids
 
+    assert_equal [6, 10], encoded.word_to_tokens(5)
+    assert_equal [38, 46], encoded.word_to_chars(5)
+    assert_equal [4, 12], encoded.token_to_chars(1)
+    assert_equal 0, encoded.token_to_word(1)
+    assert_equal 7, encoded.char_to_token(41)
+    assert_equal 10, encoded.char_to_token(48)
+
     # decode
     assert_equal "Mythological creatures like the mighty gryphon inspire awe!", tokenizer.decode(encoded.ids)
   end
@@ -60,5 +67,12 @@ class TokenizersTest < Minitest::Test
 
     # decode
     assert_equal "cafeethmagicayo", tokenizer.decode(encoded.ids)
+  end
+
+  def test_id_token_conversion
+    tokenizer = Tokenizers.from_pretrained("bert-base-cased")
+
+    assert_equal 1169, tokenizer.token_to_id("can")
+    assert_equal "magic", tokenizer.id_to_token(3974)
   end
 end


### PR DESCRIPTION
This PR adds the following methods to Tokenizer:

- add_tokens (different from add_special_tokens)
- token_to_id
- id_to_token

and the following methods to Encoding:

- word_to_tokens
- word_to_chars
- token_to_sequence
- token_to_chars
- token_to_word
- char_to_token
- char_to_word

The Python [Tokenizer](https://github.com/huggingface/tokenizers/blob/main/bindings/python/src/tokenizer.rs) and [Encoding](https://github.com/huggingface/tokenizers/blob/main/bindings/python/src/encoding.rs) bindings were used as a reference.

There are some additional updates that I'd like to make as a follow up.  Most notably:

1. Updating the `encode` method to better match the complete signature [here](https://github.com/huggingface/tokenizers/blob/33a57e64183808eea106e956df97571aa768822a/bindings/python/src/tokenizer.rs#L865), including support for `pair` and pretokenization
2. Some version of [encode_batch](https://github.com/huggingface/tokenizers/blob/33a57e64183808eea106e956df97571aa768822a/bindings/python/src/tokenizer.rs#L935), as the sequence methods don't really serve a purpose without it.  We can't easily get the parallelism benefit though.

But this batch seemed pretty straightforward on its own and of reasonable benefit.