### PR TITLE
Add support for pretokenized arguments to encode/encode_batch

### DIFF
--- a/ext/tokenizers/src/lib.rs
+++ b/ext/tokenizers/src/lib.rs
@@ -36,7 +36,7 @@ fn init() -> RbResult<()> {
     class.define_method("train", method!(RbTokenizer::train, 2))?;
     class.define_method("save", method!(RbTokenizer::save, 1))?;
     class.define_method("add_tokens", method!(RbTokenizer::add_tokens, 1))?;
-    class.define_method("_encode", method!(RbTokenizer::encode, 3))?;
+    class.define_method("_encode", method!(RbTokenizer::encode, 4))?;
     class.define_method("_encode_batch", method!(RbTokenizer::encode_batch, 3))?;
     class.define_method("decode", method!(RbTokenizer::decode, 1))?;
     class.define_method("decoder=", method!(RbTokenizer::set_decoder, 1))?;

--- a/lib/tokenizers/tokenizer.rb
+++ b/lib/tokenizers/tokenizer.rb
@@ -2,12 +2,12 @@ module Tokenizers
   class Tokenizer
     extend FromPretrained
 
-    def encode(sequence, pair = nil, add_special_tokens: true)
-      _encode(sequence, pair, add_special_tokens)
+    def encode(sequence, pair = nil, is_pretokenized: false, add_special_tokens: true)
+      _encode(sequence, pair, is_pretokenized, add_special_tokens)
     end
 
-    def encode_batch(input, add_special_tokens: true)
-      _encode_batch(input, false, add_special_tokens)
+    def encode_batch(input, is_pretokenized: false, add_special_tokens: true)
+      _encode_batch(input, is_pretokenized, add_special_tokens)
     end
 
     def enable_padding(**options)

--- a/test/tokenizer_test.rb
+++ b/test/tokenizer_test.rb
@@ -102,4 +102,18 @@ class TokenizerTest < Minitest::Test
     expected_tokens = ["[CLS]", "Am", "I", "allowed", "to", "pass", "two", "text", "arguments", "?", "[SEP]", "Yes", "I", "am", "!", "[SEP]"]
     assert_equal expected_tokens, encoded.tokens
   end
+
+  def test_pretokenized_encoding
+    tokenizer = Tokenizers.from_pretrained("bert-base-cased")
+    sequence = "A mellifluous sequence"
+    pair = "And its malodorous pair"
+
+    pretokenized_sequence = sequence.split(" ")
+    pretokenized_pair = pair.split(" ")
+
+    encoded_wout_pretokenization = tokenizer.encode(sequence, pair)
+    encoded_with_pretokenization = tokenizer.encode(pretokenized_sequence, pretokenized_pair, is_pretokenized: true)
+
+    assert_equal encoded_wout_pretokenization.tokens, encoded_with_pretokenization.tokens
+  end
 end


### PR DESCRIPTION
@ankane My Rust / Magnus is a little weak, so this definitely needs a review.  But I think I got most of what's required to get pretokenized inputs working, and my test on encode with pretokenization works.

I didn't try to add encode_batch testing, since you've got that in the quicktest which appears to be under development.

I think the `todo!`s need replacement with explicit returned errors, but I'm not sure what error messages or conventions you want to implement, so I left that as an outstanding item.

Happy to get any feedback you may have.