### PR TITLE
Add normalizers

### DIFF
--- a/lib/tokenizers.rb
+++ b/lib/tokenizers.rb
@@ -6,6 +6,7 @@ rescue LoadError
 end
 
 # modules
+require_relative "tokenizers/bert_normalizer"
 require_relative "tokenizers/bpe"
 require_relative "tokenizers/bpe_trainer"
 require_relative "tokenizers/byte_level"
@@ -16,6 +17,7 @@ require_relative "tokenizers/from_pretrained"
 require_relative "tokenizers/metaspace"
 require_relative "tokenizers/punctuation"
 require_relative "tokenizers/split"
+require_relative "tokenizers/strip"
 require_relative "tokenizers/template_processing"
 require_relative "tokenizers/tokenizer"
 require_relative "tokenizers/version"

--- a/lib/tokenizers/bert_normalizer.rb
+++ b/lib/tokenizers/bert_normalizer.rb
@@ -1,0 +1,7 @@
+module Tokenizers
+  class BertNormalizer
+    def self.new(clean_text: true, handle_chinese_chars: true, strip_accents: nil, lowercase: true)
+      _new(clean_text, handle_chinese_chars, strip_accents, lowercase)
+    end
+  end
+end

--- a/lib/tokenizers/strip.rb
+++ b/lib/tokenizers/strip.rb
@@ -1,0 +1,7 @@
+module Tokenizers
+  class Strip
+    def self.new(left: true, right: true)
+      _new(left, right)
+    end
+  end
+end

--- a/test/normalizer_test.rb
+++ b/test/normalizer_test.rb
@@ -2,8 +2,86 @@ require_relative "test_helper"
 
 class NormalizerTest < Minitest::Test
   def test_bert_normalizer
-    model = Tokenizers::BertNormalizer.new
-    assert_instance_of Tokenizers::BertNormalizer, model
-    assert_kind_of Tokenizers::Normalizer, model
+    normalizer = Tokenizers::BertNormalizer.new
+    assert_instance_of Tokenizers::BertNormalizer, normalizer
+    assert_kind_of Tokenizers::Normalizer, normalizer
+
+    normalizer = Tokenizers::BertNormalizer.new(clean_text: false)
+    assert_instance_of Tokenizers::BertNormalizer, normalizer
+    assert_kind_of Tokenizers::Normalizer, normalizer
+
+    normalizer = Tokenizers::BertNormalizer.new(handle_chinese_chars: false)
+    assert_instance_of Tokenizers::BertNormalizer, normalizer
+    assert_kind_of Tokenizers::Normalizer, normalizer
+
+    normalizer = Tokenizers::BertNormalizer.new(strip_accents: false)
+    assert_instance_of Tokenizers::BertNormalizer, normalizer
+    assert_kind_of Tokenizers::Normalizer, normalizer
+
+    normalizer = Tokenizers::BertNormalizer.new(lowercase: false)
+    assert_instance_of Tokenizers::BertNormalizer, normalizer
+    assert_kind_of Tokenizers::Normalizer, normalizer
+  end
+
+  def test_lowercase
+    normalizer = Tokenizers::Lowercase.new
+    assert_instance_of Tokenizers::Lowercase, normalizer
+    assert_kind_of Tokenizers::Lowercase, normalizer
+  end
+
+  def test_nfc
+    normalizer = Tokenizers::NFC.new
+    assert_instance_of Tokenizers::NFC, normalizer
+    assert_kind_of Tokenizers::NFC, normalizer
+  end
+
+  def test_nfd
+    normalizer = Tokenizers::NFD.new
+    assert_instance_of Tokenizers::NFD, normalizer
+    assert_kind_of Tokenizers::NFD, normalizer
+  end
+
+  def test_nfkc
+    normalizer = Tokenizers::NFKC.new
+    assert_instance_of Tokenizers::NFKC, normalizer
+    assert_kind_of Tokenizers::NFKC, normalizer
+  end
+
+  def test_nfkd
+    normalizer = Tokenizers::NFKD.new
+    assert_instance_of Tokenizers::NFKD, normalizer
+    assert_kind_of Tokenizers::NFKD, normalizer
+  end
+
+  def test_nmt
+    normalizer = Tokenizers::Nmt.new
+    assert_instance_of Tokenizers::Nmt, normalizer
+    assert_kind_of Tokenizers::Nmt, normalizer
+  end
+
+  def test_replace
+    normalizer = Tokenizers::Replace.new('abc', 'xyz')
+    assert_instance_of Tokenizers::Replace, normalizer
+    assert_kind_of Tokenizers::Replace, normalizer
+  end
+
+  def test_strip
+    normalizer = Tokenizers::Strip.new
+    assert_instance_of Tokenizers::Strip, normalizer
+    assert_kind_of Tokenizers::Strip, normalizer
+
+    normalizer = Tokenizers::Strip.new(left: false)
+    assert_instance_of Tokenizers::Strip, normalizer
+    assert_kind_of Tokenizers::Strip, normalizer
+
+    normalizer = Tokenizers::Strip.new(right: false)
+    assert_instance_of Tokenizers::Strip, normalizer
+    assert_kind_of Tokenizers::Strip, normalizer
+  end
+
+  def test_strip_accents
+    normalizer = Tokenizers::StripAccents.new
+    assert_instance_of Tokenizers::StripAccents, normalizer
+    assert_kind_of Tokenizers::StripAccents, normalizer
   end
 end


### PR DESCRIPTION
This adds most of the normalizers.  Key items:

1. Skips the precompiled normalizer, since I'm not sure how that's actually supposed to be used based on the Python comments.
2. Uses RbPattern, but doesn't have the Regex bit for the Replace normalizer
3. I was wrong about the name conflict (I was confusing Strip and Split), but the namespace is still pretty crowded.  A submodule is probably advisable.