### PR TITLE
Fix the default replacement character for the Metaspace encoder

### DIFF
--- a/lib/tokenizers/metaspace.rb
+++ b/lib/tokenizers/metaspace.rb
@@ -1,6 +1,6 @@
 module Tokenizers
   class Metaspace
-    def self.new(replacement: '_', add_prefix_space: true)
+    def self.new(replacement: "\u2581", add_prefix_space: true)
       _new(replacement, add_prefix_space)
     end
   end


### PR DESCRIPTION
I used a "_" as opposed to the correct Unicode character when I set this originally.