### PR TITLE
Add Decoders

### DIFF
--- a/ext/tokenizers/src/decoders.rs
+++ b/ext/tokenizers/src/decoders.rs
@@ -7,6 +7,10 @@ use magnus::{
 };
 use serde::{Deserialize, Serialize};
 use tk::decoders::bpe::BPEDecoder;
+use tk::decoders::byte_level::ByteLevel;
+use tk::decoders::ctc::CTC;
+use tk::decoders::metaspace::Metaspace;
+use tk::decoders::wordpiece::WordPiece;
 use tk::decoders::DecoderWrapper;
 use tk::Decoder;
 
@@ -27,8 +31,40 @@ impl Decoder for RbDecoder {
 pub struct RbBPEDecoder {}
 
 impl RbBPEDecoder {
+    pub fn new(suffix: String) -> RbDecoder {
+        BPEDecoder::new(suffix).into()
+    }
+}
+
+pub struct RbByteLevelDecoder {}
+
+impl RbByteLevelDecoder {
     pub fn new() -> RbDecoder {
-        BPEDecoder::default().into()
+        ByteLevel::default().into()
+    }
+}
+
+pub struct RbCTC {}
+
+impl RbCTC {
+    pub fn new(pad_token: String, word_delimiter_token: String, cleanup: bool) -> RbDecoder {
+        CTC::new(pad_token, word_delimiter_token, cleanup).into()
+    }
+}
+
+pub struct RbMetaspaceDecoder {}
+
+impl RbMetaspaceDecoder {
+    pub fn new(replacement: char, add_prefix_space: bool) -> RbDecoder {
+        Metaspace::new(replacement, add_prefix_space).into()
+    }
+}
+
+pub struct RbWordPieceDecoder {}
+
+impl RbWordPieceDecoder {
+    pub fn new(prefix: String, cleanup: bool) -> RbDecoder {
+        WordPiece::new(prefix, cleanup).into()
     }
 }
 
@@ -89,6 +125,26 @@ unsafe impl TypedData for RbDecoder {
                     class.undef_alloc_func();
                     class
                 }),
+                DecoderWrapper::ByteLevel(_) => *memoize!(RClass: {
+                    let class: RClass = module().const_get("ByteLevelDecoder").unwrap();
+                    class.undef_alloc_func();
+                    class
+                }),
+                DecoderWrapper::CTC(_) => *memoize!(RClass: {
+                    let class: RClass = module().const_get("CTC").unwrap();
+                    class.undef_alloc_func();
+                    class
+                }),
+                DecoderWrapper::Metaspace(_) => *memoize!(RClass: {
+                    let class: RClass = module().const_get("MetaspaceDecoder").unwrap();
+                    class.undef_alloc_func();
+                    class
+                }),
+                DecoderWrapper::WordPiece(_) => *memoize!(RClass: {
+                    let class: RClass = module().const_get("WordPieceDecoder").unwrap();
+                    class.undef_alloc_func();
+                    class
+                }),
                 _ => todo!(),
             },
         }
@@ -99,7 +155,19 @@ pub fn decoders(module: &RModule) -> RbResult<()> {
     let decoder = module.define_class("Decoder", Default::default())?;
 
     let class = module.define_class("BPEDecoder", decoder)?;
-    class.define_singleton_method("new", function!(RbBPEDecoder::new, 0))?;
+    class.define_singleton_method("_new", function!(RbBPEDecoder::new, 1))?;
+
+    let class = module.define_class("ByteLevelDecoder", decoder)?;
+    class.define_singleton_method("new", function!(RbByteLevelDecoder::new, 0))?;
+
+    let class = module.define_class("CTC", decoder)?;
+    class.define_singleton_method("_new", function!(RbCTC::new, 3))?;
+
+    let class = module.define_class("MetaspaceDecoder", decoder)?;
+    class.define_singleton_method("_new", function!(RbMetaspaceDecoder::new, 2))?;
+
+    let class = module.define_class("WordPieceDecoder", decoder)?;
+    class.define_singleton_method("_new", function!(RbWordPieceDecoder::new, 2))?;
 
     Ok(())
 }

--- a/lib/tokenizers.rb
+++ b/lib/tokenizers.rb
@@ -7,18 +7,22 @@ end
 
 # modules
 require_relative "tokenizers/bpe"
+require_relative "tokenizers/bpe_decoder"
 require_relative "tokenizers/bpe_trainer"
 require_relative "tokenizers/byte_level"
 require_relative "tokenizers/char_bpe_tokenizer"
+require_relative "tokenizers/ctc"
 require_relative "tokenizers/digits"
 require_relative "tokenizers/encoding"
 require_relative "tokenizers/from_pretrained"
 require_relative "tokenizers/metaspace"
+require_relative "tokenizers/metaspace_decoder"
 require_relative "tokenizers/punctuation"
 require_relative "tokenizers/split"
 require_relative "tokenizers/template_processing"
 require_relative "tokenizers/tokenizer"
 require_relative "tokenizers/version"
+require_relative "tokenizers/word_piece_decoder"
 
 module Tokenizers
   class Error < StandardError; end

--- a/lib/tokenizers/bpe_decoder.rb
+++ b/lib/tokenizers/bpe_decoder.rb
@@ -1,0 +1,7 @@
+module Tokenizers
+  class BPEDecoder
+    def self.new(suffix: "</w>")
+      _new(suffix)
+    end
+  end
+end

--- a/lib/tokenizers/ctc.rb
+++ b/lib/tokenizers/ctc.rb
@@ -1,0 +1,7 @@
+module Tokenizers
+  class CTC
+    def self.new(pad_token: "<pad>", word_delimiter_token: "|", cleanup: true)
+      _new(pad_token, word_delimiter_token, cleanup)
+    end
+  end
+end

--- a/lib/tokenizers/metaspace_decoder.rb
+++ b/lib/tokenizers/metaspace_decoder.rb
@@ -1,0 +1,7 @@
+module Tokenizers
+  class MetaspaceDecoder
+    def self.new(replacement: "\u2581", add_prefix_space: true)
+      _new(replacement, add_prefix_space)
+    end
+  end
+end

--- a/lib/tokenizers/word_piece_decoder.rb
+++ b/lib/tokenizers/word_piece_decoder.rb
@@ -1,0 +1,7 @@
+module Tokenizers
+  class WordPieceDecoder
+    def self.new(prefix: '##', cleanup: true)
+      _new(prefix, cleanup)
+    end
+  end
+end

--- a/test/decoder_test.rb
+++ b/test/decoder_test.rb
@@ -5,5 +5,61 @@ class DecoderTest < Minitest::Test
     decoder = Tokenizers::BPEDecoder.new
     assert_instance_of Tokenizers::BPEDecoder, decoder
     assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::BPEDecoder.new(suffix: "</end>")
+    assert_instance_of Tokenizers::BPEDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+  end
+
+  def test_byte_level
+    decoder = Tokenizers::ByteLevelDecoder.new
+    assert_instance_of Tokenizers::ByteLevelDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+  end
+
+  def test_ctc
+    decoder = Tokenizers::CTC.new
+    assert_instance_of Tokenizers::CTC, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::CTC.new(pad_token: "<mypad>")
+    assert_instance_of Tokenizers::CTC, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::CTC.new(word_delimiter_token: "+")
+    assert_instance_of Tokenizers::CTC, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::CTC.new(cleanup: false)
+    assert_instance_of Tokenizers::CTC, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+  end
+
+  def test_metaspace
+    decoder = Tokenizers::MetaspaceDecoder.new
+    assert_instance_of Tokenizers::MetaspaceDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::MetaspaceDecoder.new(replacement: "+")
+    assert_instance_of Tokenizers::MetaspaceDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::MetaspaceDecoder.new(add_prefix_space: false)
+    assert_instance_of Tokenizers::MetaspaceDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+  end
+
+  def test_word_piece
+    decoder = Tokenizers::WordPieceDecoder.new
+    assert_instance_of Tokenizers::WordPieceDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::WordPieceDecoder.new(prefix: "+")
+    assert_instance_of Tokenizers::WordPieceDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
+
+    decoder = Tokenizers::WordPieceDecoder.new(cleanup: false)
+    assert_instance_of Tokenizers::WordPieceDecoder, decoder
+    assert_kind_of Tokenizers::Decoder, decoder
   end
 end


### PR DESCRIPTION
This PR adds most of the decoders.  Specifically it:

1. Adds optional argument for the existing BPEDecoder
2. Adds all the other decoders except for Sequence (I'm not sure how that's actually invoked from the Ruby side)

This PR does run into a whole bunch of name conflicts.  ByteLevel and Metaspace with the PreTokenizers and WordPiece with the models.  I just added "Decoder" to the end of the names for now.