### PR TITLE
Leverage new `rb-sys` features for simplified CI and cross-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,17 +10,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            tmp
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: ruby/setup-ruby@v1
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cargo-cache: true
       - run: bundle exec rake compile
       - run: bundle exec rake download:files
       - run: bundle exec rake test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
           ruby-version: 3.3
           bundler-cache: true
           cargo-cache: true
-      - run: |
+      - if: ${{ matrix.platform != 'x64-mingw-ucrt' }}
+        run: |
           cargo install --locked --git https://github.com/ankane/cargo-3pl
           git clone https://github.com/ankane/3pl-source.git
           rust_target="$(bundle exec ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").rust_target')"
@@ -53,7 +54,6 @@ jobs:
   test-macos:
     needs: release
     runs-on: macos-latest
-    name: Test macOS
     strategy:
       matrix:
         platform: [x86_64-darwin]
@@ -70,7 +70,6 @@ jobs:
   test-windows:
     needs: release
     runs-on: windows-latest
-    name: Test Windows
     strategy:
       matrix:
         platform: [x64-mingw-ucrt]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,18 @@ jobs:
         platform: [x86_64-darwin]
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
       - uses: actions/download-artifact@v3
         with:
           name: cross-gem-${{ matrix.platform }}
       - name: Test
         run: |
-          gem install --no-document --force ${{ steps.download.outputs.artifacts }}
-          ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("I can feel the magic, can you?").tokens'
+          echo "::group::Install gem"
+          gem install --no-document --verbose tokenizers-*.gem
+          echo "::endgroup::"
+          ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("Standing on the moon, I see a shadow on the sun").tokens'
 
   test-windows:
     needs: release
@@ -75,16 +80,19 @@ jobs:
         platform: [x64-mingw-ucrt]
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
       - uses: actions/download-artifact@v3
         with:
           name: cross-gem-${{ matrix.platform }}
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 3.3
       - name: Test
+        shell: bash
         run: |
-          gem install --no-document --force ${{ steps.download.outputs.artifacts }}
-          ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("I can feel the magic, can you?").tokens'
+          echo "::group::Install gem"
+          gem install --no-document --verbose tokenizers-*.gem
+          echo "::endgroup::"
+          ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("Between the dawn and the dark of night").tokens'
 
   test-linux:
     needs: release
@@ -98,7 +106,6 @@ jobs:
           - aarch64-linux
           - aarch64-linux-musl
     runs-on: ubuntu-latest
-    name: Test ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2
@@ -106,20 +113,27 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: cross-gem-${{ matrix.platform }}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
       - name: Test
         run: |
-          docker_platform="$(bundle exec ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").docker_platform')"
-          if [[ "${{ matrix.platform }}" == *-musl ]]; then
-            base_image="alpine:latest"
-            install_cmd="apk add --no-cache ruby"
-          else
-            base_image="${{ matrix.platform }}"
-            install_cmd="apt-get update && apt-get install -y ruby"
+          gem install rb_sys --version 0.9.94
+          docker_platform="$(ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").docker_platform')"
+          gem_path="$(find . -name "tokenizers-*.gem" | head -n 1)"
+          if [ ! -f "$gem_path" ]; then
+            echo "Tokenizers gem not found at $gem_path"
+            exit 1
           fi
-          docker buildx build --platform $docker_platform -t test-${{ matrix.platform }} - <<EOF
+          if [[ "${{ matrix.platform }}" == *-musl ]]; then
+            base_image="ruby:3-alpine"
+          else
+            base_image="ruby:3-slim"
+          fi
+          cat > Dockerfile.test <<EOF
           FROM $base_image
-          RUN $install_cmd
-          COPY *.gem /tmp/
-          RUN gem install /tmp/*.gem
-          RUN ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("I can feel the magic, can you?").tokens'
+          COPY $gem_path /tmp/tokenizers.gem
+          RUN gem install --no-document --verbose /tmp/tokenizers.gem
+          RUN ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("What a long strange trip its been").tokens'
           EOF
+          docker buildx build --platform $docker_platform -t test-${{ matrix.platform }} -f Dockerfile.test .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: release
+
 on:
   workflow_dispatch:
   # TODO: remove
   push:
     branches:
       - rb-sys-updates
+
 jobs:
   ci-data:
     runs-on: ubuntu-latest
@@ -14,11 +16,10 @@ jobs:
       - id: fetch
         uses: oxidize-rb/actions/fetch-ci-data@v1
         with:
-          # Windows builds seem to compile properly, so may be worth enabling
           supported-ruby-platforms: |
             exclude:
               - x64-mingw32
-              - x64-mingw-ucrt
+
   release:
     needs: ci-data
     strategy:
@@ -46,5 +47,80 @@ jobs:
           ruby-versions: "3.3,3.2,3.1"
       - uses: actions/upload-artifact@v3
         with:
-          name: cross-gem
+          name: cross-gem-${{ matrix.platform }}
           path: ${{ steps.cross-gem.outputs.gem-path }}
+
+  test-macos:
+    needs: release
+    runs-on: macos-latest
+    name: Test macOS
+    strategy:
+      matrix:
+        platform: [x86_64-darwin]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: cross-gem-${{ matrix.platform }}
+      - name: Test
+        run: |
+          gem install --no-document --force ${{ steps.download.outputs.artifacts }}
+          ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("I can feel the magic, can you?").tokens'
+
+  test-windows:
+    needs: release
+    runs-on: windows-latest
+    name: Test Windows
+    strategy:
+      matrix:
+        platform: [x64-mingw-ucrt]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: cross-gem-${{ matrix.platform }}
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+      - name: Test
+        run: |
+          gem install --no-document --force ${{ steps.download.outputs.artifacts }}
+          ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("I can feel the magic, can you?").tokens'
+
+  test-linux:
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arm-linux
+          - x86_64-linux
+          - x86_64-linux-musl
+          - aarch64-linux
+          - aarch64-linux-musl
+    runs-on: ubuntu-latest
+    name: Test ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: cross-gem-${{ matrix.platform }}
+      - name: Test
+        run: |
+          docker_platform="$(bundle exec ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").docker_platform')"
+          if [[ "${{ matrix.platform }}" == *-musl ]]; then
+            base_image="alpine:latest"
+            install_cmd="apk add --no-cache ruby"
+          else
+            base_image="${{ matrix.platform }}"
+            install_cmd="apt-get update && apt-get install -y ruby"
+          fi
+          docker buildx build --platform $docker_platform -t test-${{ matrix.platform }} - <<EOF
+          FROM $base_image
+          RUN $install_cmd
+          COPY *.gem /tmp/
+          RUN gem install /tmp/*.gem
+          RUN ruby -rtokenizers -e 'print Tokenizers.from_pretrained("bert-base-cased").encode("I can feel the magic, can you?").tokens'
+          EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: release
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  # TODO: remove
+  push:
+    branches:
+      - rb-sys-updates
 jobs:
   ci-data:
     runs-on: ubuntu-latest
@@ -23,16 +28,16 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.platform }}
     steps:
+      - uses: actions/checkout@v4
       - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
         with:
           ruby-version: 3.3
           bundler-cache: true
           cargo-cache: true
-      - uses: actions/checkout@v4
       - run: |
           cargo install --locked --git https://github.com/ankane/cargo-3pl
           git clone https://github.com/ankane/3pl-source.git
-          rust_target="$(ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").rust_target')"
+          rust_target="$(bundle exec ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").rust_target')"
           cargo 3pl --target $rust_target --require-files --source 3pl-source > LICENSE-THIRD-PARTY.txt
       - uses: oxidize-rb/actions/cross-gem@v1
         id: cross-gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: release
 
 on:
   workflow_dispatch:
-  # TODO: remove
-  push:
-    branches:
-      - rb-sys-updates
 
 jobs:
   ci-data:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,44 @@
 name: release
 on: workflow_dispatch
 jobs:
+  ci-data:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.fetch.outputs.result }}
+    steps:
+      - id: fetch
+        uses: oxidize-rb/actions/fetch-ci-data@v1
+        with:
+          # Windows builds seem to compile properly, so may be worth enabling
+          supported-ruby-platforms: |
+            exclude:
+              - x64-mingw32
+              - x64-mingw-ucrt
   release:
+    needs: ci-data
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: x86_64-linux
-            target: x86_64-unknown-linux-gnu
-          - platform: x86_64-linux-musl
-            target: x86_64-unknown-linux-musl
-          - platform: aarch64-linux
-            target: aarch64-unknown-linux-gnu
-          - platform: x86_64-darwin
-            target: x86_64-apple-darwin
-            # Rust uses external command to strip symbols and debuginfo on Mac
-            # Do not do for arm64 since it interferes with code signing
-            # and codesign binary is not present to re-sign
-            setup: sudo ln -s /opt/osxcross/target/bin/x86_64-apple-darwin-strip /usr/local/bin/strip
-          - platform: arm64-darwin
-            target: aarch64-apple-darwin
-          # - platform: x64-mingw-ucrt
-          #   target: x86_64-pc-windows-gnu
-          # - platform: x64-mingw32
-          #   target: x86_64-pc-windows-gnu
+        platform: ${{ fromJSON(needs.ci-data.outputs.result).supported-ruby-platforms }}
     runs-on: ubuntu-latest
     name: ${{ matrix.platform }}
     steps:
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+          cargo-cache: true
       - uses: actions/checkout@v4
       - run: |
           cargo install --locked --git https://github.com/ankane/cargo-3pl
           git clone https://github.com/ankane/3pl-source.git
-          cargo 3pl --target ${{ matrix.target }} --require-files --source 3pl-source > LICENSE-THIRD-PARTY.txt
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.2
+          rust_target="$(ruby -rrb_sys -e 'puts RbSys::ToolchainInfo.new("${{ matrix.platform }}").rust_target')"
+          cargo 3pl --target $rust_target --require-files --source 3pl-source > LICENSE-THIRD-PARTY.txt
       - uses: oxidize-rb/actions/cross-gem@v1
         id: cross-gem
         with:
           platform: ${{ matrix.platform }}
           ruby-versions: "3.3,3.2,3.1"
-          # pre-script: ${{ matrix.setup }}
       - uses: actions/upload-artifact@v3
         with:
           name: cross-gem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,18 +568,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.91"
+version = "0.9.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81203e271055178603e243fee397f5f4aac125bcd20036279683fb1445a899"
+checksum = "06dab8dbb0beb0a575a80c4b46355c8ace1f3dc5df60a3109758f205f1061366"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.91"
+version = "0.9.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de9403a6aac834e7c9534575cb14188b6b5b99bafe475d18d838d44fbc27d31"
+checksum = "164d44950a42f2ba2f94efdcb650e14764270f84d281352aebb261806da0b2ce"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ RbSys::ToolchainInfo.supported_ruby_platforms.each do |platform|
   task "native:#{platform}" do
     sh "bundle", "exec", "rb-sys-dock", "--ruby-versions", "3.1,3.2,3.3", "--platform", platform, "--build"
   end
-end
+end unless File.file?("/etc/rubybashrc") # inside rb-sys container already
 
 task :remove_ext do
   path = "lib/tokenizers/tokenizers.bundle"


### PR DESCRIPTION
This PR updates the project to utilize the latest features of `rb-sys`.

## Key changes

- Simplify GitHub Actions workflows by using pre-built actions from `oxidize-rb/actions`
- Enable some new platforms:
  * `arm-linux`
  * `aarch64-linux-musl`
  * `x64-mingw-ucrt` [^1]
- Add smoke tests for many of the platform gems
- Replace `Rake::ExtensionTask` with `RbSys::ExtensionTask` since it does the same thing as the old custom code
- Upgrade `rb-sys` and `rb-sys-build` crates to version 0.9.94.

## Tophat

For reference, you can see the passing CI builds here:

- `release` -> https://github.com/ianks/tokenizers-ruby/actions/runs/8732060423
- `build` -> https://github.com/ianks/tokenizers-ruby/actions/runs/8732060426

[^1]: [3pl fails currently because `winapi-x86_64-pc-windows-gnu v0.4.0`](https://github.com/ianks/tokenizers-ruby/actions/runs/8731242470/job/23956339282), how should I fix?