### PR TITLE
Fix url escaping for HuggingFace

### DIFF
--- a/lib/tokenizers/from_pretrained.rb
+++ b/lib/tokenizers/from_pretrained.rb
@@ -27,7 +27,9 @@ module Tokenizers
         headers["Authorization"] = "Bearer #{auth_token}"
       end
 
-      url = "https://huggingface.co/%s/resolve/%s/tokenizer.json" % [identifier, revision].map { |v| CGI.escape(v) }
+      # Escape path segments individually to preserve '/' in identifiers like "org/model"
+      escaped_identifier = identifier.split("/").map { |v| CGI.escape(v) }.join("/")
+      url = "https://huggingface.co/#{escaped_identifier}/resolve/#{CGI.escape(revision)}/tokenizer.json"
 
       path =
         begin

--- a/test/tokenizer_test.rb
+++ b/test/tokenizer_test.rb
@@ -54,6 +54,16 @@ class TokenizerTest < Minitest::Test
     assert_equal "Model \"bad\" on the Hub doesn't have a tokenizer", error.message
   end
 
+  def test_from_pretrained_with_org_identifier
+    # Identifiers with org/model format should work (the slash should not be escaped)
+    tokenizer = Tokenizers.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
+    assert_kind_of Tokenizers::Tokenizer, tokenizer
+
+    encoded = tokenizer.encode("Hello world")
+    assert_kind_of Array, encoded.ids
+    refute_empty encoded.ids
+  end
+
   def test_add_special_tokens
     tokenizer = Tokenizers.from_pretrained("bert-base-cased")
 


### PR DESCRIPTION
URL escaping breaks model identifiers with slashes

## Summary

The `Tokenizers.from_pretrained` method fails for Hugging Face models that have organization names in their identifiers (e.g., `M-CLIP/XLM-Roberta-Large-Vit-B-32`).

## Reproduction

```ruby
require 'tokenizers'

# This fails with: Tokenizers::Error: Model "M-CLIP/XLM-Roberta-Large-Vit-B-32" on the Hub doesn't have a tokenizer
Tokenizers.from_pretrained("M-CLIP/XLM-Roberta-Large-Vit-B-32")
```

## Fix

In `lib/tokenizers/from_pretrained.rb` line 30, the code uses `CGI.escape` on the entire identifier:

```ruby
url = "https://huggingface.co/%s/resolve/%s/tokenizer.json" % [identifier, revision].map { |v| CGI.escape(v) }
```
This escapes the `/` in the model identifier to `%2F`, resulting in a malformed URL which causes HuggingFace to return 400 error.

Escape each path segment individually while preserving the `/` separator:

```ruby
escaped_identifier = identifier.split("/").map { |v| CGI.escape(v) }.join("/")
url = "https://huggingface.co/#{escaped_identifier}/resolve/#{CGI.escape(revision)}/tokenizer.json"
```

## Affected Models

Any model with an organization prefix

